### PR TITLE
Make files available through require & import

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
     "tangle",
     "iota"
   ],
+  "files": [ 
+    "/lib/multisig.js",  
+    "/lib/transfer.js" 
+  ], 
   "authors": [
     "Paul Handy (paul@iota.org)",
     "Chris Dukakis (chris.dukakis@iota.org)",


### PR DESCRIPTION
For when you import the project with npm/yarn, this lets you access the multisig file with:
`import multisig from 'iota.flash.js/lib/multisig'`