### PR TITLE
Changed used root object in createTransaction

### DIFF
--- a/examples/functions.js
+++ b/examples/functions.js
@@ -26,6 +26,7 @@ const createTransaction = (user, actions, close) => {
   let newTansfers
   try {
     // Check if its closing the channel
+    let rootToUse = toUse.multisig;
     if (!close) {
       // Prepare the transfer.
       newTansfers = transfer.prepare(
@@ -38,6 +39,7 @@ const createTransaction = (user, actions, close) => {
       // Distribute the remaining channel balance amongst the channel users
       // NOTE: YOU MUST PASS THE SETTLEMENT ADDRESSES ARRAY as 'actions'
       newTansfers = transfer.close(actions, user.flash.deposit)
+      rootToUse = user.flash.root;
     }
 
     // Compose the transfer bundles
@@ -45,7 +47,7 @@ const createTransaction = (user, actions, close) => {
       user.flash.balance,
       user.flash.deposit,
       user.flash.outputs,
-      toUse.multisig,
+      rootToUse,
       user.flash.remainderAddress,
       user.flash.transfers,
       newTansfers,


### PR DESCRIPTION
The wrong root object is passed to `transfer.compose` if the channel is closed in `createTransaction`.